### PR TITLE
Combine payment method distribution and churn plots

### DIFF
--- a/customer_churn.ipynb
+++ b/customer_churn.ipynb
@@ -105,7 +105,7 @@
       "metadata": {},
       "execution_count": null,
       "outputs": [],
-      "source": "plt.figure(figsize=(8,6))\nsns.countplot(y='PaymentMethod', data=df, order=df['PaymentMethod'].value_counts().index)\nplt.title('Payment Method Distribution')\nplt.show()\nplt.figure(figsize=(8,6))\nsns.countplot(data=df, x='PaymentMethod', hue='Churn', order=df['PaymentMethod'].value_counts().index)\nplt.xticks(rotation=45)\nplt.title('Churn by Payment Method')\nplt.show()\n"
+      "source": "order = df['PaymentMethod'].value_counts().index\npalette = sns.color_palette('pastel')\nfig, axes = plt.subplots(1, 2, figsize=(16,6))\nsns.countplot(ax=axes[0], data=df, x='PaymentMethod', order=order, palette=palette)\naxes[0].set_title('Payment Method Distribution')\naxes[0].tick_params(axis='x', rotation=45)\nsns.countplot(ax=axes[1], data=df, x='PaymentMethod', hue='Churn', order=order, palette=palette)\naxes[1].set_title('Churn by Payment Method')\naxes[1].tick_params(axis='x', rotation=45)\nplt.tight_layout()\nplt.show()\n"
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Place overall PaymentMethod distribution and churn breakdown on shared subplot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf5b9b33c832b8ed004a33d6cca05