### PR TITLE
Consolidate churn EDA plots and add visualization summary

### DIFF
--- a/customer_churn.ipynb
+++ b/customer_churn.ipynb
@@ -1,195 +1,357 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Telco Customer Churn EDA\nExploratory data analysis for the IBM Telco Customer Churn dataset."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "import pandas as pd\nimport numpy as np\nimport matplotlib.pyplot as plt\nimport seaborn as sns\nfrom sklearn.preprocessing import LabelEncoder\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.metrics import classification_report, accuracy_score\n"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Load dataset"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "df = pd.read_csv('data/WA_Fn-UseC_-Telco-Customer-Churn.csv')\ndf.head()"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Check for missing values"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "df.isnull().sum()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Data Cleaning\n- Partner, PaperlessBilling, and Churn converted to integers (1 for Yes, 0 for No).\n- TotalCharges contained blanks for 11 customers with tenure 0 (less than a month); these rows were removed."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "yes_no_cols = ['Partner','PaperlessBilling','Churn']\nle = LabelEncoder()\nfor col in yes_no_cols:\n    df[col] = le.fit_transform(df[col])\n\ndf['TotalCharges'] = pd.to_numeric(df['TotalCharges'], errors='coerce')\nrows_before = df.shape[0]\ndf = df.dropna(subset=['TotalCharges'])\nrows_after = df.shape[0]\nprint(f'Dropped {rows_before-rows_after} rows due to missing TotalCharges')\n"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Exploratory Data Analysis"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Gender and Churn Distributions"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "fig, axes = plt.subplots(1, 2, figsize=(12, 6))\naxes[0].pie(df['gender'].value_counts(), labels=df['gender'].value_counts().index, autopct='%1.1f%%', startangle=90)\naxes[0].set_title('Gender Distribution')\naxes[1].pie(df['Churn'].value_counts(), labels=['No','Yes'], autopct='%1.1f%%', startangle=90)\naxes[1].set_title('Churn Distribution')\nplt.show()\n"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Customer contract distribution"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "plt.figure(figsize=(8,6))\nsns.countplot(data=df, x='Contract', hue='Churn')\nplt.title('Customer Contract Distribution by Churn')\nplt.show()\n"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Payment method distribution"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "order = df['PaymentMethod'].value_counts().index\npalette = sns.color_palette('pastel')\nfig, axes = plt.subplots(1, 2, figsize=(16,6))\nsns.countplot(ax=axes[0], data=df, x='PaymentMethod', order=order, palette=palette)\naxes[0].set_title('Payment Method Distribution')\naxes[0].tick_params(axis='x', rotation=45)\nsns.countplot(ax=axes[1], data=df, x='PaymentMethod', hue='Churn', order=order, palette=palette)\naxes[1].set_title('Churn by Payment Method')\naxes[1].tick_params(axis='x', rotation=45)\nplt.tight_layout()\nplt.show()\n"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Dependents and Partners"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "plt.figure(figsize=(8,6))\nsns.countplot(data=df, x='Dependents', hue='Churn')\nplt.title('Dependents Distribution by Churn')\nplt.show()\nplt.figure(figsize=(8,6))\nsns.countplot(data=df, x='Partner', hue='Churn')\nplt.title('Partner Distribution by Churn')\nplt.show()\n"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Services and Churn"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "plt.figure(figsize=(8,6))\nsns.countplot(data=df, x='OnlineSecurity', hue='Churn')\nplt.title('Churn w.r.t Online Security')\nplt.show()\nplt.figure(figsize=(8,6))\nsns.countplot(data=df, x='PaperlessBilling', hue='Churn')\nplt.title('Churn w.r.t Paperless Billing')\nplt.show()\nplt.figure(figsize=(8,6))\nsns.countplot(data=df, x='TechSupport', hue='Churn')\nplt.title('Churn w.r.t Tech Support')\nplt.show()\nplt.figure(figsize=(8,6))\nsns.countplot(data=df, x='PhoneService', hue='Churn')\nplt.title('Churn w.r.t Phone Service')\nplt.show()\n"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Charges and Tenure"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "sns.set_context('paper', font_scale=1.1)\nfig = plt.figure(figsize=(14, 8))\ngs = fig.add_gridspec(2, 2)\n\nax1 = fig.add_subplot(gs[0, 0])\nsns.kdeplot(df.MonthlyCharges[df['Churn'] == 0], ax=ax1, color='Red', fill=True, label='Not Churn')\nsns.kdeplot(df.MonthlyCharges[df['Churn'] == 1], ax=ax1, color='Blue', fill=True, label='Churn')\nax1.set_title('Distribution of monthly charges by churn')\nax1.set_xlabel('Monthly Charges')\nax1.set_ylabel('Density')\nax1.legend()\n\nax2 = fig.add_subplot(gs[0, 1])\nsns.kdeplot(df.TotalCharges[df['Churn'] == 0], ax=ax2, color='Gold', fill=True, label='Not Churn')\nsns.kdeplot(df.TotalCharges[df['Churn'] == 1], ax=ax2, color='Green', fill=True, label='Churn')\nax2.set_title('Distribution of total charges by churn')\nax2.set_xlabel('Total Charges')\nax2.set_ylabel('Density')\nax2.legend()\n\nax3 = fig.add_subplot(gs[1, :])\nsns.boxplot(x='Churn', y='tenure', data=df, ax=ax3)\nax3.set_title('Tenure vs Churn')\nax3.set_xlabel('Churn')\nax3.set_ylabel('Tenure (Months)')\n\nplt.tight_layout()\nplt.show()\n"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Correlation Heatmap"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "plt.figure(figsize=(25, 10))\ncorr = df.apply(lambda x: pd.factorize(x)[0]).corr()\nmask = np.triu(np.ones_like(corr, dtype=bool))\nax = sns.heatmap(corr, mask=mask, xticklabels=corr.columns, yticklabels=corr.columns, annot=True, linewidths=.2, cmap='coolwarm', vmin=-1, vmax=1)\nplt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": "## Logistic Regression Model"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "execution_count": null,
-      "outputs": [],
-      "source": "X = df.drop(columns=['Churn'])\nX = pd.get_dummies(X, drop_first=True)\ny = df['Churn']\nX_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42, stratify=y)\nmodel = LogisticRegression(max_iter=1000)\nmodel.fit(X_train, y_train)\npreds = model.predict(X_test)\nprint('Accuracy:', accuracy_score(y_test, preds))\nprint(classification_report(y_test, preds))\n"
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.x",
-      "pygments_lexer": "ipython3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Telco Customer Churn EDA\nExploratory data analysis for the IBM Telco Customer Churn dataset."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import pandas as pd\nimport numpy as np\nimport matplotlib.pyplot as plt\nimport seaborn as sns\nfrom sklearn.preprocessing import LabelEncoder\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.metrics import classification_report, accuracy_score\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "df = pd.read_csv('data/WA_Fn-UseC_-Telco-Customer-Churn.csv')\ndf.head()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check for missing values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "df.isnull().sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Cleaning\n- Partner, PaperlessBilling, and Churn converted to integers (1 for Yes, 0 for No).\n- TotalCharges contained blanks for 11 customers with tenure 0 (less than a month); these rows were removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "yes_no_cols = ['Partner','PaperlessBilling','Churn']\nle = LabelEncoder()\nfor col in yes_no_cols:\n    df[col] = le.fit_transform(df[col])\n\ndf['TotalCharges'] = pd.to_numeric(df['TotalCharges'], errors='coerce')\nrows_before = df.shape[0]\ndf = df.dropna(subset=['TotalCharges'])\nrows_after = df.shape[0]\nprint(f'Dropped {rows_before-rows_after} rows due to missing TotalCharges')\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary statistics\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "stats = df[['tenure','MonthlyCharges','TotalCharges']].agg(['count','mean','median','std','min','max'])\n",
+    "stats.loc['mode'] = df[['tenure','MonthlyCharges','TotalCharges']].mode().iloc[0]\n",
+    "stats\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exploratory Data Analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Gender and Churn Distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "fig, axes = plt.subplots(1, 2, figsize=(12, 6))\naxes[0].pie(df['gender'].value_counts(), labels=df['gender'].value_counts().index, autopct='%1.1f%%', startangle=90)\naxes[0].set_title('Gender Distribution')\naxes[1].pie(df['Churn'].value_counts(), labels=['No','Yes'], autopct='%1.1f%%', startangle=90)\naxes[1].set_title('Churn Distribution')\nplt.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Customer contract distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "plt.figure(figsize=(8,6))\nsns.countplot(data=df, x='Contract', hue='Churn')\nplt.title('Customer Contract Distribution by Churn')\nplt.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Payment method distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "order = df['PaymentMethod'].value_counts().index\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(16,6))\n",
+    "sns.countplot(ax=axes[0], data=df, x='PaymentMethod', order=order)\n",
+    "axes[0].set_title('Payment Method Distribution')\n",
+    "axes[0].tick_params(axis='x', rotation=45)\n",
+    "ct = pd.crosstab(df['PaymentMethod'], df['Churn'])\n",
+    "ct.plot(kind='bar', stacked=True, ax=axes[1])\n",
+    "axes[1].set_title('Churn by Payment Method')\n",
+    "axes[1].set_xlabel('Payment Method')\n",
+    "axes[1].tick_params(axis='x', rotation=45)\n",
+    "axes[1].legend(title='Churn')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dependents and Partners"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 2, figsize=(12,5))\n",
+    "sns.countplot(ax=axes[0], data=df, x='Dependents', hue='Churn')\n",
+    "axes[0].set_title('Dependents vs Churn')\n",
+    "sns.countplot(ax=axes[1], data=df, x='Partner', hue='Churn')\n",
+    "axes[1].set_title('Partner vs Churn')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Services and Churn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "services = ['OnlineSecurity', 'PaperlessBilling', 'TechSupport', 'PhoneService']\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(14,10))\n",
+    "for ax, service in zip(axes.flatten(), services):\n",
+    "    sns.countplot(ax=ax, data=df, x=service, hue='Churn')\n",
+    "    ax.set_title(f'Churn vs {service}')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Charges and Tenure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(18,5))\n",
+    "sns.kdeplot(data=df, x='MonthlyCharges', hue='Churn', fill=True, ax=axes[0])\n",
+    "axes[0].set_title('Monthly Charges by Churn')\n",
+    "sns.kdeplot(data=df, x='TotalCharges', hue='Churn', fill=True, ax=axes[1])\n",
+    "axes[1].set_title('Total Charges by Churn')\n",
+    "sns.boxplot(x='Churn', y='tenure', data=df, ax=axes[2])\n",
+    "axes[2].set_title('Tenure vs Churn')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Correlation Heatmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(25, 10))\ncorr = df.apply(lambda x: pd.factorize(x)[0]).corr()\nmask = np.triu(np.ones_like(corr, dtype=bool))\nax = sns.heatmap(corr, mask=mask, xticklabels=corr.columns, yticklabels=corr.columns, annot=True, linewidths=.2, cmap='coolwarm', vmin=-1, vmax=1)\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary of useful plots\n",
+    "\n",
+    "- **Crosstab / stacked bar**: categorical vs churn (gender, contract, payment, internet service).\n",
+    "- **Regplot / scatter**: numeric vs churn (monthly charges, tenure, total charges).\n",
+    "- **Box/violin plots**: numeric distributions by churn group.\n",
+    "- **Heatmaps**: churn proportions across service categories.\n",
+    "\n",
+    "Below are example charts for each plot type.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Crosstab / stacked bar example\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "contract_churn = pd.crosstab(df['Contract'], df['Churn'])\n",
+    "contract_churn.div(contract_churn.sum(1), axis=0).plot(kind='bar', stacked=True)\n",
+    "plt.title('Contract Type vs Churn')\n",
+    "plt.ylabel('Proportion')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Regplot examples for numeric features vs churn\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1,3, figsize=(18,5))\n",
+    "sns.regplot(x='MonthlyCharges', y='Churn', data=df, ax=axes[0])\n",
+    "sns.regplot(x='tenure', y='Churn', data=df, ax=axes[1])\n",
+    "sns.regplot(x='TotalCharges', y='Churn', data=df, ax=axes[2])\n",
+    "axes[0].set_title('Monthly Charges')\n",
+    "axes[1].set_title('Tenure')\n",
+    "axes[2].set_title('Total Charges')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Box plots by churn group\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1,3, figsize=(18,5))\n",
+    "sns.boxplot(x='Churn', y='MonthlyCharges', data=df, ax=axes[0])\n",
+    "sns.boxplot(x='Churn', y='tenure', data=df, ax=axes[1])\n",
+    "sns.boxplot(x='Churn', y='TotalCharges', data=df, ax=axes[2])\n",
+    "axes[0].set_title('Monthly Charges')\n",
+    "axes[1].set_title('Tenure')\n",
+    "axes[2].set_title('Total Charges')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Heatmap of service-related churn rates\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "services = ['OnlineSecurity','TechSupport','PhoneService','InternetService']\n",
+    "heatmap_data = pd.DataFrame({feature: df.groupby(feature)['Churn'].mean() for feature in services}).T\n",
+    "sns.heatmap(heatmap_data, annot=True, cmap='Reds')\n",
+    "plt.title('Churn proportion by service category')\n",
+    "plt.ylabel('Service')\n",
+    "plt.xlabel('Category')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Logistic Regression Model"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "X = df.drop(columns=['Churn'])\nX = pd.get_dummies(X, drop_first=True)\ny = df['Churn']\nX_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42, stratify=y)\nmodel = LogisticRegression(max_iter=1000)\nmodel.fit(X_train, y_train)\npreds = model.predict(X_test)\nprint('Accuracy:', accuracy_score(y_test, preds))\nprint(classification_report(y_test, preds))\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- Combine payment method distribution with churn breakdown using stacked bars.
- Merge Dependents and Partner churn plots into a single figure.
- Group OnlineSecurity, PaperlessBilling, TechSupport and PhoneService churn charts in a 2×2 layout.
- Streamline MonthlyCharges, TotalCharges and tenure plots in one row.
- Add a summary of useful plot types for churn analysis.
- Compute summary statistics for tenure, monthly charges and total charges, and include example plots for crosstab, regplot, box plots and heatmaps.

## Testing
- `pytest`