### PR TITLE
feat: engineer service features and clarify EDA

### DIFF
--- a/customer_churn.ipynb
+++ b/customer_churn.ipynb
@@ -14,6 +14,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Import necessary libraries\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -203,7 +204,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>5 rows × 21 columns</p>\n",
+       "<p>5 rows \u00d7 21 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -244,6 +245,7 @@
     }
    ],
    "source": [
+    "# Load the Telco customer churn dataset\n",
     "df = pd.read_csv('data/WA_Fn-UseC_-Telco-Customer-Churn.csv')\n",
     "df.head()"
    ]
@@ -293,6 +295,7 @@
     }
    ],
    "source": [
+    "# Convert TotalCharges to numeric and identify missing values\n",
     "# Looking at the data, some fields are blank in `TotalCharges`.\n",
     "df['TotalCharges'] = pd.to_numeric(df.TotalCharges, errors='coerce')\n",
     "df.isnull().sum()"
@@ -329,6 +332,7 @@
     }
    ],
    "source": [
+    "# Encode binary 'Yes/No' columns and remove rows with missing TotalCharges\n",
     "yes_no_cols = ['Partner','PaperlessBilling','Churn']\n",
     "le = LabelEncoder()\n",
     "for col in yes_no_cols:\n",
@@ -339,6 +343,43 @@
     "df = df.dropna(subset=['TotalCharges'])\n",
     "rows_after = df.shape[0]\n",
     "print(f'Dropped {rows_before-rows_after} rows due to missing TotalCharges')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Feature engineering for service columns\n",
+    "\n",
+    "- Combine phone service and multiple line service into a single categorical feature.\n",
+    "- Normalize InternetService-related columns and encode them as flags.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Feature engineering for phone and internet service columns\n",
+    "# Consolidate phone and multiple line services into one column\n",
+    "df['PhoneService'] = df.apply(\n",
+    "    lambda row: 'Multiple' if row['MultipleLines'] == 'Yes'\n",
+    "    else ('1' if row['PhoneService'] == 'Yes' else '0'),\n",
+    "    axis=1\n",
+    ")\n",
+    "df.drop(columns=['MultipleLines'], inplace=True)\n",
+    "\n",
+    "# Standardize InternetService categories and convert dependent services to flags\n",
+    "df['InternetService'] = df['InternetService'].replace('No', 'No internet service')\n",
+    "internet_cols = ['OnlineSecurity','OnlineBackup','DeviceProtection',\n",
+    "                 'TechSupport','StreamingTV','StreamingMovies']\n",
+    "for col in internet_cols:\n",
+    "    df[col] = df.apply(\n",
+    "        lambda row: 0 if row['InternetService'] == 'No internet service'\n",
+    "        else (1 if row[col] == 'Yes' else 0),\n",
+    "        axis=1\n",
+    "    )\n"
    ]
   },
   {
@@ -443,6 +484,7 @@
     }
    ],
    "source": [
+    "# Summary statistics for numerical columns\n",
     "stats = df[['tenure','MonthlyCharges','TotalCharges']].agg(['count','mean','median','std','min','max'])\n",
     "stats.loc['mode'] = df[['tenure','MonthlyCharges','TotalCharges']].mode().iloc[0]\n",
     "stats\n"
@@ -479,6 +521,7 @@
     }
    ],
    "source": [
+    "# Visualize gender distribution and churn ratio\n",
     "fig, axes = plt.subplots(1, 2, figsize=(12, 6))\n",
     "axes[0].pie(df['gender'].value_counts(), labels=df['gender'].value_counts().index, autopct='%1.1f%%', startangle=90)\n",
     "axes[0].set_title('Gender Distribution')\n",
@@ -511,6 +554,7 @@
     }
    ],
    "source": [
+    "# Examine contract types by churn outcome\n",
     "plt.figure(figsize=(8,6))\n",
     "sns.countplot(data=df, x='Contract', hue='Churn')\n",
     "plt.title('Customer Contract Distribution by Churn')\n",
@@ -541,6 +585,7 @@
     }
    ],
    "source": [
+    "# Analyze distribution of payment methods and churn\n",
     "order = df['PaymentMethod'].value_counts().index\n",
     "fig, axes = plt.subplots(1, 2, figsize=(16,6))\n",
     "sns.countplot(ax=axes[0], data=df, x='PaymentMethod', order=order)\n",
@@ -580,6 +625,7 @@
     }
    ],
    "source": [
+    "# Explore relationships between dependents, partners, and churn\n",
     "fig, axes = plt.subplots(1, 2, figsize=(12,5))\n",
     "sns.countplot(ax=axes[0], data=df, x='Dependents', hue='Churn')\n",
     "axes[0].set_title('Dependents vs Churn')\n",
@@ -613,6 +659,7 @@
     }
    ],
    "source": [
+    "# Compare churn rates across various service subscriptions\n",
     "services = ['OnlineSecurity', 'PaperlessBilling', 'TechSupport', 'PhoneService']\n",
     "fig, axes = plt.subplots(2, 2, figsize=(14,10))\n",
     "for ax, service in zip(axes.flatten(), services):\n",
@@ -646,6 +693,7 @@
     }
    ],
    "source": [
+    "# Investigate charges and tenure against churn\n",
     "fig, axes = plt.subplots(1, 3, figsize=(18,5))\n",
     "sns.kdeplot(data=df, x='MonthlyCharges', hue='Churn', fill=True, ax=axes[0])\n",
     "axes[0].set_title('Monthly Charges by Churn')\n",
@@ -681,6 +729,7 @@
     }
    ],
    "source": [
+    "# Display correlation heatmap to inspect feature relationships\n",
     "plt.figure(figsize=(25, 10))\n",
     "corr = df.apply(lambda x: pd.factorize(x)[0]).corr()\n",
     "mask = np.triu(np.ones_like(corr, dtype=bool))\n",
@@ -726,6 +775,7 @@
     }
    ],
    "source": [
+    "# Example of crosstab/stacked bar for contract type vs churn\n",
     "contract_churn = pd.crosstab(df['Contract'], df['Churn'])\n",
     "contract_churn.div(contract_churn.sum(1), axis=0).plot(kind='bar', stacked=True)\n",
     "plt.title('Contract Type vs Churn')\n",
@@ -757,6 +807,7 @@
     }
    ],
    "source": [
+    "# Regression plots for numeric features vs churn\n",
     "fig, axes = plt.subplots(1,3, figsize=(18,5))\n",
     "sns.regplot(x='MonthlyCharges', y='Churn', data=df, ax=axes[0])\n",
     "sns.regplot(x='tenure', y='Churn', data=df, ax=axes[1])\n",
@@ -792,6 +843,7 @@
     }
    ],
    "source": [
+    "# Box plots showing distribution of numeric features by churn\n",
     "fig, axes = plt.subplots(1,3, figsize=(18,5))\n",
     "sns.boxplot(x='Churn', y='MonthlyCharges', data=df, ax=axes[0])\n",
     "sns.boxplot(x='Churn', y='tenure', data=df, ax=axes[1])\n",
@@ -827,6 +879,7 @@
     }
    ],
    "source": [
+    "# Heatmap of churn rates across service categories\n",
     "services = ['OnlineSecurity','TechSupport','PhoneService','InternetService']\n",
     "heatmap_data = pd.DataFrame({feature: df.groupby(feature)['Churn'].mean() for feature in services}).T\n",
     "sns.heatmap(heatmap_data, annot=True, cmap='Reds')\n",


### PR DESCRIPTION
## Summary
- collapse phone and multiple line service into single feature
- encode internet-related services as flags when InternetService is absent
- document EDA cells with explanatory comments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad278848d0832bb83482e3d89e1bff